### PR TITLE
fix: archive gem URL conversion and broken links

### DIFF
--- a/_data/commons.yml
+++ b/_data/commons.yml
@@ -11,13 +11,13 @@ menu:
     url: 'https://devfest-perros-guirec.tpopsite.com/'
     tooltip: "Accéder à la boutique"
   - title: Sponsoring
-    url: '/sponsors'
+    url: '/sponsors.html'
     tooltip: "Devenir sponsor"
   - title: Archives
     url: '/archives'
     tooltip: "Accéder aux archives"
   - title: À propos
-    url: './a-propos'
+    url: './a-propos.html'
     tooltip: "En savoir plus sur l'événement"
   - title: ""
     url: 'https://www.linkedin.com/company/code-d-armor/'

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
 
   <title>{{ page.title}}</title>
 
-  <link rel="apple-touch-icon" sizes="180x180" href="{{site.baseurl}}/apple-touch-icon.webp">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{site.baseurl}}/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="{{site.baseurl}}/favicon-32x32.webp">
   <link rel="icon" type="image/png" sizes="16x16" href="{{site.baseurl}}/favicon-16x16.webp">
   <link rel="manifest" href="{{site.baseurl}}/site.webmanifest">

--- a/gems/archive/bin/archive
+++ b/gems/archive/bin/archive
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'pathname'
 
 if ARGV.empty?
   puts "Usage: bundle exec archive <folder>"
@@ -31,18 +32,39 @@ Dir.glob("#{build_path}/*").each do |file|
   File.directory?(file) ? FileUtils.cp_r(file, target) : FileUtils.cp(file, target)
 end
 
+# Get relative path from a file to the archive root
+def relative_prefix(file_path, archive_path)
+  file_dir = File.dirname(file_path)
+  rel_path = Pathname.new(file_dir).relative_path_from(Pathname.new(archive_path))
+  return '' if rel_path.to_s == '.'
+  rel_path.to_s.split('/').map { '..' }.join('/') + '/'
+end
+
 # Fix URLs in HTML/CSS/JS files
 puts "Fixing URLs..."
 Dir.glob("#{archive_path}/**/*.{html,css,js}").each do |file|
   content = File.read(file)
   original = content.dup
+  prefix = relative_prefix(file, archive_path)
 
-  content.gsub!(/href="\/assets\//, 'href="assets/')
-  content.gsub!(/href='\/assets\//, "href='assets/")
-  content.gsub!(/src="\/assets\//, 'src="assets/')
-  content.gsub!(/src='\/assets\//, "src='assets/")
-  content.gsub!(/url\("?\/(assets\/[^"\)]+)\)?/, 'url(\1)')
-  content.gsub!(/url\('?\/(assets\/[^'\)]+)\)?/, "url('\1')")
+  # Fix /assets/ paths -> relative assets/
+  content.gsub!(/href="\/assets\//, 'href="' + prefix + 'assets/')
+  content.gsub!(/href='\/assets\//, "href='" + prefix + "assets/")
+  content.gsub!(/src="\/assets\//, 'src="' + prefix + 'assets/')
+  content.gsub!(/src='\/assets\//, "src='" + prefix + "assets/")
+
+  # Fix other root-relative paths -> relative paths
+  # Use block form to properly handle backreferences
+  content.gsub!(/href="\/([^"]*)"/) { "href=\"#{prefix}#{$1}\"" }
+  content.gsub!(/href='\/([^']*)'/) { "href='#{prefix}#{$1}'" }
+  content.gsub!(/src="\/([^"]*)"/) { "src=\"#{prefix}#{$1}\"" }
+  content.gsub!(/src='\/([^']*)'/) { "src='#{prefix}#{$1}'" }
+
+  # Fix CSS url() patterns
+  # url(/assets/...) -> url(relative/assets/...)
+  content.gsub!(/url\(['"]?\/(assets\/[^'"\)]+)['"]?\)/) { "url(#{prefix}#{$1})" }
+  # url(/other-path) -> url(relative/other-path)
+  content.gsub!(/url\(['"]?\/([^'"\)]+)['"]?\)/) { "url(#{prefix}#{$1})" }
 
   File.write(file, content) if content != original
 end
@@ -56,7 +78,19 @@ if File.exist?('archives.md')
   unless content.include?(archive_url)
     display_name = "DevFest #{folder}"
     new_entry = "  - title: #{display_name}\n    url: #{archive_url}"
-    content = content.sub(/(archives:\n)/, "\1#{new_entry}\n")
+
+    # Try different patterns to find where to insert
+    if content =~ /archives:\s*\n/
+      # Standard format: archives:\n  - title: ...
+      content = content.sub(/(archives:\s*\n)/, '\\1' + "#{new_entry}\n")
+    elsif content =~ /archives_title:.*\n/
+      # Missing archives: key, add it after archives_title
+      content = content.sub(/(archives_title:.*\n)/) { "#{$1}archives:\n#{new_entry}\n" }
+    else
+      # Fallback: add before slidedecks
+      content = content.sub(/(slidedecks_title:)/, "archives:\n#{new_entry}\n\\1")
+    end
+
     File.write('archives.md', content)
     puts "Added to archives menu: #{display_name}"
   end


### PR DESCRIPTION
## Summary

Fixes the archive gem to properly handle URL conversion and fixes broken links in templates.

### Archive Gem Fixes
- Fix Ruby control character bug where \\1 was interpreted as ASCII 1 instead of regex backreference
- Add proper relative path calculation for nested files
- Convert all root-relative URLs (not just /assets/) to relative paths
- Fix archives.md entry insertion with proper backreference handling

### Template Fixes
- Fix apple-touch-icon.webp → apple-touch-icon.png (file doesn't exist as webp)
- Add .html extension to /sponsors and ./a-propos menu links

## Test Results
- 47/47 links now pass (100%)

## Commits
- 98456ba fix(archive): fix URL conversion and backreference bugs
- ab2ca21 fix: correct broken links in templates