### PR TITLE
Add workflow to notify website repo on master push

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,0 +1,17 @@
+name: Notify website of updates
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website sync
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${{ secrets.WEBSITE_DISPATCH_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/Code-d-Armor/website/dispatches \
+            -d '{"event_type":"conference-updated"}'


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/notify-website.yml`
- On every push to `master`, calls the GitHub API to fire a `repository_dispatch` (`conference-updated`) event on `Code-d-Armor/website`
- Uses the `WEBSITE_DISPATCH_TOKEN` repo secret (a fine-grained PAT scoped to the website repo, already added) for auth
- Companion PR on the receiving side: https://github.com/Code-d-Armor/website/pull/2

## How it works
1. Push lands on `master` here
2. This workflow POSTs to `repos/Code-d-Armor/website/dispatches` with `event_type: conference-updated`
3. Website's `sync-from-conference.yml` workflow receives the dispatch, merges `conference/master` in, and pushes

## Test plan
- [ ] Merge this PR and the companion website PR
- [ ] Push a trivial commit to `master` here and confirm the website repo's Actions tab shows a triggered "Sync from conference" run
- [ ] Confirm the merge lands on `Code-d-Armor/website`'s `master` and its Pages deploy runs